### PR TITLE
Docker: Fix an issue were native dependencies weren't able to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,12 @@ FROM node:lts-alpine
 RUN mkdir -p /usr/src/fosscord-gateway
 WORKDIR /usr/src/fosscord-gateway
 COPY package.json /usr/src/fosscord-gateway
+RUN apk add --no-cache --virtual build-dependencies add \
+    python \
+    make \
+    g++
 RUN npm install
+RUN apk del build-dependencies
 COPY . /usr/src/fosscord-gateway
 EXPOSE 3002
 CMD ["npm", "start"]


### PR DESCRIPTION
This PR fixes an issue were deps wouldn't be able to build at the time of composing 