### PR TITLE
Add thread_member_lists to LazyRequest

### DIFF
--- a/src/schema/LazyRequest.ts
+++ b/src/schema/LazyRequest.ts
@@ -5,6 +5,7 @@ export interface LazyRequest {
 	threads?: boolean;
 	typing?: true;
 	members?: any[];
+	thread_member_lists?: any[];
 }
 
 export const LazyRequest = {
@@ -14,4 +15,5 @@ export const LazyRequest = {
 	$typing: Boolean,
 	$threads: Boolean,
 	$members: [] as any[],
+	$thread_member_lists: [] as any[],
 };


### PR DESCRIPTION
LazyRequest was missing thread_member_lists, thus clients were disconnected from the gateway with error code 4002 (decode error) everytime they sent LazyRequests. The client would then try to reconnect and do a LazyRequest which would put it into a loop of disconnects and reconnects. 