### PR TITLE
Migrate docker builds to GitHub Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: docker-publish
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_TAGS }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      -
+        # Hackfix to cleanup cache; replace after buildx 0.6 and BuildKit 0.9 are released
+        # https://github.com/docker/build-push-action/pull/406#issuecomment-879184394
+        name: Move cache fix
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
## Prerequisites
The new GHA workflow requires 3 secrets to be set:
`DOCKERHUB_USERNAME` - the username of the Docker Hub account that hosts the images, in this case **fosscord**
`DOCKERHUB_TOKEN` - an API token for the user account that hosts the images on Docker Hub
`DOCKERHUB_TAGS` - a combination of the username, image name and image tags for the Docker Hub, in this case **fosscord/gateway:latest**

## Changes
Docker Hub [no longer](https://www.docker.com/blog/changes-to-docker-hub-autobuilds) provides free builds for Free tiers which made the Docker Hub integration for this project obsolete. This PR adds a workflow that builds and pushes the image to Docker Hub using GitHub Actions.