### PR TITLE
[Dockerfile] Copy package-lock.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 WORKDIR /usr/src/fosscord-gateway
 COPY package.json .
+COPY package-lock.json .
 RUN apk --no-cache --virtual build-dependencies add \
     python \
     make \


### PR DESCRIPTION
Copy package-lock.json into container environment. Required change to avoid problems caused by unforeseen npm package updates.
